### PR TITLE
sensorservice: customize sensor fusion mag filter via prop

### DIFF
--- a/services/sensorservice/Fusion.cpp
+++ b/services/sensorservice/Fusion.cpp
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 
+#include <cutils/properties.h>
 #include <utils/Log.h>
 
 #include "Fusion.h"
@@ -63,9 +64,8 @@ static const float FREE_FALL_THRESHOLD_SQ =
  * Fields strengths greater than this likely indicate a local magnetic
  * disturbance which we do not want to update into the fused frame.
  */
-static const float MAX_VALID_MAGNETIC_FIELD = 100; // uT
-static const float MAX_VALID_MAGNETIC_FIELD_SQ =
-        MAX_VALID_MAGNETIC_FIELD*MAX_VALID_MAGNETIC_FIELD;
+static const int MAX_VALID_MAGNETIC_FIELD = 100; // uT
+#define MAX_VALID_MAGNETIC_FIELD_PROP "ro.fusion.magfield.max"
 
 /*
  * Values of the field smaller than this should be ignored in fusion to avoid
@@ -169,6 +169,10 @@ Fusion::Fusion() {
 
     x0 = 0;
     x1 = 0;
+
+    maxValidMagFieldSq = property_get_int32(
+        MAX_VALID_MAGNETIC_FIELD_PROP, MAX_VALID_MAGNETIC_FIELD);
+    maxValidMagFieldSq = maxValidMagFieldSq * maxValidMagFieldSq;
 
     init();
 }
@@ -296,7 +300,7 @@ status_t Fusion::handleMag(const vec3_t& m) {
     // the geomagnetic-field should be between 30uT and 60uT
     // reject if too large to avoid spurious magnetic sources
     const float magFieldSq = length_squared(m);
-    if (magFieldSq > MAX_VALID_MAGNETIC_FIELD_SQ) {
+    if (magFieldSq > maxValidMagFieldSq) {
         return BAD_VALUE;
     } else if (magFieldSq < MIN_VALID_MAGNETIC_FIELD_SQ) {
         // Also reject if too small since we will get ill-defined (zero mag)

--- a/services/sensorservice/Fusion.h
+++ b/services/sensorservice/Fusion.h
@@ -53,6 +53,11 @@ class Fusion {
      */
     mat<mat33_t, 2, 2> GQGt;
 
+    /**
+     * the maximum acceptable geomagnetic-field (square)
+     */
+    float maxValidMagFieldSq;
+
 public:
     Fusion();
     void init();


### PR DESCRIPTION
When large magnetic fields values get filtered out by the Sensor
Fusion algorithm the fused sensors (rotation vector, gravity, linear
acceleration etc) do not produce any output. As a result the CTS tests
fail if the compass is uncalibrated on some devices.

This change allows the magnetic field filter to be tweaked on a
per-device basis to allow the fused sensors to operate even when the
compass in uncalibrated.

Change-Id: I608b307e8b7712e806315a6181c19130ec17c847